### PR TITLE
Build improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "http://maven.restlet.org" }
+    maven { url "https://maven.restlet.org" }
   }
 
   // Get rid of that [expletive deleted] warning about xml-apis 2.0.2/1.0.b2
@@ -13,9 +13,9 @@ buildscript {
   }
 
   dependencies {
-    classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'
-    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.29-99'
-    classpath group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.5'
+    classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.4.0'
+    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.30-99'
+    classpath group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.6'
   }
 }
 


### PR DESCRIPTION
Update the versions of some components, including `xmlcalabash1-gradle` to remove annoying warnings about things that are deprecated in gradle 6.

Switch to `https:` for restlet