### PR TITLE
Added cause QName to error

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -948,6 +948,7 @@ Error =
       name.ncname.attr?,
       attribute type { xsd:QName }?,
       attribute code { xsd:QName }?,
+      attribute cause { xsd:QName }?,
       attribute href { xsd:anyURI }?,
       attribute line { xsd:integer }?,
       attribute column { xsd:integer }?,


### PR DESCRIPTION
This change, along with the corresponding change in the `3.0-specification` repository is an attempt to resolve issue 955 on the specification.