### PR TITLE
Change how file-info.attributes are handled

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -795,7 +795,7 @@ VocabDirectory =
    element c:directory {
       attribute name { text },
       xmlbase.attr,
-      file-info.attributes*,
+      file-info.attributes,
       ((VocabFile|VocabDirectory|VocabOther)*)
    }
 [
@@ -805,7 +805,7 @@ VocabFile =
    element c:file {
       attribute name { text },
       xmlbase.attr,
-      file-info.attributes*,
+      file-info.attributes,
       content-type.attr?,
       empty
    }
@@ -816,11 +816,11 @@ VocabOther =
    element c:other {
       attribute name { text },
       xmlbase.attr,
-      file-info.attributes*,
+      file-info.attributes,
       empty
    }
 
-file-info.attributes = size.attr | readable.attr | writable.attr | last-modified.attr | hidden.attr
+file-info.attributes = size.attr?, readable.attr?, writable.attr?, last-modified.attr?, hidden.attr?
 size.attr = attribute size { xsd:integer }
 readable.attr = attribute readable { xsd:boolean }
 writable.attr = attribute writable { xsd:boolean }


### PR DESCRIPTION
The current schema is entirely correct from a RELAX NG perspective, but it uses a formulation that the stylesheets that produce the grammar tableaux can't parse. I looked at fixing that and decided it was too much work.

This equivalent definition works without any changes to the stylesheets.

Fix steps issue 396.