### PR TITLE
Require p:options to precede p:declare-steps

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -226,7 +226,8 @@ Library =
       common.attributes,
       global.attributes,
       (Import|ImportFunctions|Documentation|PipeInfo)*,
-      (DeclareStep|StaticOption|Documentation|PipeInfo)*
+      (StaticOption|Documentation|PipeInfo)*,
+      (DeclareStep|Documentation|PipeInfo)*
    }
 
 [


### PR DESCRIPTION
This closes https://github.com/xproc/3.0-specification/issues/1050
