### PR TITLE
Making port required on p:run-input

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -716,7 +716,7 @@ Step-run =
 ]
 RunInput =
    element run-input {
-      port.attr?,
+      port.attr,
       select.attr?,
       [ sa:avt = "true" ]
          href.attr?,


### PR DESCRIPTION
Attempt to fix-532 in step repo: Attribute `port` is required on `p:run-input`