### PR TITLE
Fix the incorrect optionality of p:with-input on p:run

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -707,7 +707,7 @@ Step-run =
     common.attributes,
     global.attributes,
     step.attributes,
-    (WithInput? & RunInput* & RunOption* & Output* & Documentation* & PipeInfo*)
+    (WithInput & RunInput* & RunOption* & Output* & Documentation* & PipeInfo*)
   }
 
 [


### PR DESCRIPTION
This is a fix for https://github.com/xproc/3.0-steps/issues/569

@xatapult are you satisfied that #36  can be closed, or could you describe what you think is incorrect, please?